### PR TITLE
fixes appcrash on receiving a notification

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -115,7 +115,7 @@
         <service android:name="ly.count.android.sdk.messaging.CountlyMessagingService" >
             <meta-data android:name="broadcast_action" android:value="ly.count.android.api.broadcast" />
         </service>
-
+	<activity android:label="@string/app_name" android:name="ly.count.android.sdk.messaging.ProxyActivity" android:noHistory="true" android:theme="@android:style/Theme.Translucent" />
     </config-file>
 
     <source-file src="src/android/CountlyCordova.java" target-dir="src/ly/count/android/sdk"/>


### PR DESCRIPTION
On receiving notification we see below error and the app crashes.

I/CountlyMessagingService(17292): Got a message from Countly Messaging: Bundle[{google.sent_time=xxxxxxxxxxxxxx, c.i=xxxxxxxxxxxxxxxxxxxxx, from=xxxxxxxxxxxxxx, google.message_id=0:xxxxxxxxxxxxxx%xxxxxxxxxxxxxx, message=Hello1, android.support.content.wakelockid=1, collapse_key=do_not_collapse}]
E/Parcel  (  848): Class not found when unmarshalling: ly.count.android.sdk.messaging.Message
E/Parcel  (  848): java.lang.ClassNotFoundException: ly.count.android.sdk.messaging.Message
E/Parcel  (  848): 	at java.lang.Class.classForName(Native Method)
E/Parcel  (  848): 	at java.lang.Class.forName(Class.java:251)
E/Parcel  (  848): 	at java.lang.Class.forName(Class.java:216)
E/Parcel  (  848): 	at android.os.Parcel.readParcelableCreator(Parcel.java:2133)
E/Parcel  (  848): 	at android.os.Parcel.readParcelable(Parcel.java:2097)
E/Parcel  (  848): 	at android.os.Parcel.readValue(Parcel.java:2013)
E/Parcel  (  848): 	at android.os.Parcel.readArrayMapInternal(Parcel.java:2314)
E/Parcel  (  848): 	at android.os.Bundle.unparcel(Bundle.java:249)
E/Parcel  (  848): 	at android.os.Bundle.getString(Bundle.java:1118)
E/Parcel  (  848): 	at android.content.Intent.getStringExtra(Intent.java:4991)
E/Parcel  (  848): 	at com.android.server.am.ActivityStackSupervisor.startActivityLocked(ActivityStackSupervisor.java:1334)
E/Parcel  (  848): 	at com.android.server.am.ActivityStackSupervisor.startActivityMayWait(ActivityStackSupervisor.java:966)
E/Parcel  (  848): 	at com.android.server.am.ActivityManagerService.startActivityAsUser(ActivityManagerService.java:3890)
E/Parcel  (  848): 	at com.android.server.am.ActivityManagerService.startActivity(ActivityManagerService.java:3793)
E/Parcel  (  848): 	at android.app.ActivityManagerNative.onTransact(ActivityManagerNative.java:159)
E/Parcel  (  848): 	at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:2532)
E/Parcel  (  848): 	at android.os.Binder.execTransact(Binder.java:404)
E/Parcel  (  848): 	at dalvik.system.NativeStart.run(Native Method)
E/Parcel  (  848): Caused by: java.lang.NoClassDefFoundError: ly/count/android/sdk/messaging/Message
E/Parcel  (  848): 	... 18 more
E/Parcel  (  848): Caused by: java.lang.ClassNotFoundException: Didn't find class "ly.count.android.sdk.messaging.Message" on path: DexPathList[[directory "."],nativeLibraryDirectories=[/vendor/lib, /system/lib]]
E/Parcel  (  848): 	at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:67)
E/Parcel  (  848): 	at java.lang.ClassLoader.loadClass(ClassLoader.java:497)
E/Parcel  (  848): 	at java.lang.ClassLoader.loadClass(ClassLoader.java:457)
E/Parcel  (  848): 	... 18 more
W/dalvikvm(17292): threadid=21: thread exiting with uncaught exception (group=0x41728da0)
E/AndroidRuntime(17292): FATAL EXCEPTION: IntentService[CountlyMessagingService]
E/AndroidRuntime(17292): Process: com.ionicframework.myapp119191, PID: 17292
E/AndroidRuntime(17292): android.content.ActivityNotFoundException: Unable to find explicit activity class {com.ionicframework.myapp119191/ly.count.android.sdk.messaging.ProxyActivity}; have you declared this activity in your AndroidManifest.xml?
E/AndroidRuntime(17292): 	at android.app.Instrumentation.checkStartActivityResult(Instrumentation.java:1648)
E/AndroidRuntime(17292): 	at android.app.Instrumentation.execStartActivity(Instrumentation.java:1442)
E/AndroidRuntime(17292): 	at android.app.ContextImpl.startActivity(ContextImpl.java:1371)
E/AndroidRuntime(17292): 	at android.app.ContextImpl.startActivity(ContextImpl.java:1353)
E/AndroidRuntime(17292): 	at android.content.ContextWrapper.startActivity(ContextWrapper.java:322)
E/AndroidRuntime(17292): 	at ly.count.android.sdk.messaging.CountlyMessagingService.notify(CountlyMessagingService.java:92)
E/AndroidRuntime(17292): 	at ly.count.android.sdk.messaging.CountlyMessagingService.onHandleIntent(CountlyMessagingService.java:75)
E/AndroidRuntime(17292): 	at android.app.IntentService$ServiceHandler.handleMessage(IntentService.java:65)
E/AndroidRuntime(17292): 	at android.os.Handler.dispatchMessage(Handler.java:102)
E/AndroidRuntime(17292): 	at android.os.Looper.loop(Looper.java:157)
E/AndroidRuntime(17292): 	at android.os.HandlerThread.run(HandlerThread.java:61)
W/ActivityManager(  848):   Force finishing activity com.ionicframework.myapp119191/.MainActivity
W/ContextImpl(  848): Calling a method in the system process without a qualified user: 