### PR TITLE
Update endEvent() to support all eventTypes

### DIFF
--- a/Countly.js
+++ b/Countly.js
@@ -150,6 +150,10 @@ Countly.endEvent = function(options){
     var eventType = "event"; //event, eventWithSum, eventWithSegment, eventWithSumSegment
     var segments = {};
 
+    if(options.eventSum)
+        eventType = "eventWithSum";
+    if(options.segments)
+        eventType = "eventWithSegment";
     if(options.segments && options.eventSum)
         eventType = "eventWithSumSegment";
 


### PR DESCRIPTION
Compared to the sendEvent the endEvent Method lacked the functionality to differentiate between all event types.